### PR TITLE
Macos pre v12 support

### DIFF
--- a/modules/juce_gui_extra/native/juce_mac_AppleRemote.mm
+++ b/modules/juce_gui_extra/native/juce_mac_AppleRemote.mm
@@ -49,10 +49,10 @@ namespace
 
         const auto defaultPort = []
         {
-           #if defined (MAC_OS_VERSION_12_0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_12_0
-            if (@available (macOS 12.0, *))
-                return kIOMainPortDefault;
-           #endif
+//            #if defined (MAC_OS_VERSION_12_0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_12_0
+//             if (@available (macOS 12.0, *))
+//                 return kIOMainPortDefault;
+//            #endif
 
             JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wdeprecated-declarations")
             return kIOMasterPortDefault;


### PR DESCRIPTION
 - comment out code path that returns a non-existing global symbol

![image](https://github.com/BeatConnect/bc_dll_juce_fork/assets/920624/9c2fadea-17d0-42ae-adc8-96dcc53ded6d)

https://developer.apple.com/documentation/iokit/kiomainportdefault

